### PR TITLE
Replace keyboard input with command line arguments

### DIFF
--- a/precice.f90
+++ b/precice.f90
@@ -63,13 +63,12 @@ contains
       arg_scope => getScope( 'athlet', 'global', 'arglist' )
       ! Get the participantName
       participantName = char(string(get(arg_scope, '-participantName')))
-
-      ! We currently get the participant and mesh name through screen input.
+      ! Get the meshName
+      meshName = char(string(get(arg_scope, '-meshName')))
+      ! Print the values
       write (*,*) 'Participant name:'
       write (*,*) participantName
-      !
       write (*,*) 'Mesh name:'
-      read (*, '(A)') meshName
       write (*,*) meshName
       !
       ! We currently hard-code the configuration file.

--- a/precice.f90
+++ b/precice.f90
@@ -50,15 +50,22 @@ contains
       type(HashMap_t),  pointer :: scope
       character(len=:), pointer :: output_id
       
+      ! Get the command-line arguments scope
+      type(HashMap_t),  pointer :: arg_scope
+      
       scope       => getScope( state_scope, 'ccc' )
       output_id   => getCharPtr( scope, 'id' )
       write(*,*) "Output ID: ", output_id
 
       write (*,*) 'ATHLET preCICE adapter: Starting...'
 
+      ! Bind pointer arg_scope to the athlet/global/arglist scope
+      arg_scope => getScope( 'athlet', 'global', 'arglist' )
+      ! Get the participantName
+      participantName = char(string(get(arg_scope, '-participantName')))
+
       ! We currently get the participant and mesh name through screen input.
       write (*,*) 'Participant name:'
-      read (*, '(A)') participantName
       write (*,*) participantName
       !
       write (*,*) 'Mesh name:'


### PR DESCRIPTION
This replaces the keyboard input of `participantName` and `meshName` with the command line arguments `-participantName` and `-meshName`.

Call ATHLET with, e.g.:
```bash
<athlet> <input_file> <id> -participantName SolverOne -meshName MeshOne
```

This is a (temporary) workaround for #1.